### PR TITLE
Build CJS and ESM outputs

### DIFF
--- a/src/typescript/mit-open-api-axios/package.json
+++ b/src/typescript/mit-open-api-axios/package.json
@@ -2,9 +2,11 @@
   "name": "@mitodl/open-api-axios",
   "version": "2024.3.18",
   "description": "Library for requesting data from mit-open APIs",
-  "main": "dist/index.js",
+  "main": "dist/cjs/index.js",
   "scripts": {
-    "build": "tsc",
+    "build": "rm -rf dist && yarn build:esm && yarn build:cjs",
+    "build:esm": "tsc",
+    "build:cjs": "tsc --module commonjs --outDir dist/cjs",
     "prepack": "npm run build"
   },
   "author": "MIT Open Learning Engineering <oldevops@mit.edu>",
@@ -13,9 +15,21 @@
     "LICENSE"
   ],
   "exports": {
-    ".": "./dist/index.js",
-    "./v0": "./dist/v0/index.js",
-    "./v1": "./dist/v1/index.js"
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js",
+      "default": "./dist/esm/index.js"
+    },
+    "./v0": {
+      "import": "./dist/esm/v0/index.js",
+      "require": "./dist/cjs/v0/index.js",
+      "default": "./dist/esm/v0/index.js"
+    },
+    "./v1": {
+      "import": "./dist/esm/v1/index.js",
+      "require": "./dist/cjs/v1/index.js",
+      "default": "./dist/esm/v1/index.js"
+    }
   },
   "license": "BSD-3",
   "devDependencies": {

--- a/src/typescript/mit-open-api-axios/tsconfig.json
+++ b/src/typescript/mit-open-api-axios/tsconfig.json
@@ -55,7 +55,7 @@
     "sourceMap": true,                                   /* Create source map files for emitted JavaScript files. */
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    "outDir": "./dist",                                  /* Specify an output folder for all emitted files. */
+    "outDir": "./dist/esm",                                  /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */


### PR DESCRIPTION
### What are the relevant tickets?
#17 

### Description (What does it do?)
Previously, we only built ES Module javascript. Now we build CommonJS and ES Module typescript.

As a concrete use case, the CJS output makes importing the package in Jest tests much easier. 

### How can this be tested?

Run:
1. `./scripts/generate.sh` to generate the API (no change)
2. Then 
    ```
    cd src/typescript/mit-open-api-axios/
    yarn build
    ```
3. Check that the `dist/` folder contains both CJS and ESM builds.

If you would like to see the CJS and ESM builds in action:

1. In the MIT Open repo
2. `git checkut cc/test-esm-and-cjs`. *This branch uses **https://github.com/ChristopherChudzicki/odl-open-api-axios/tree/cc/cjs-also**, a repo I created with the contents of `@mitodl/open-api-axios` so I could install it from git. (git installation doesn't work for JS packages that are in subdirectories.) The generated files were **slightly** edited:*
    - I added `console.log("hello from @mitodl/open-api-client/dist/esm/index.js");` to the ESM build
    - I added `console.log("hello from @mitodl/open-api-client/dist/cjs/index.js");` to the CJS build
3. Run `docker compose up`. Visit http://localhost:3000. In the JS console, you should see `"hello from @mitodl/open-api-client/dist/esm/index.js"`. **Webpack is using the ESM build**.
4. Run `docker compose exec watch yarn test ./frontends/mit-open/src/foo.test.ts` In the terminal output, you should see `"hello from @mitodl/open-api-client/dist/cjs/index.js"` **Jest is using the CJS build.**
    - Jest does not support ESM builds, and by default does not transform `node_modules` 

### Additional Context
Primarily my motivation for this was making usage in Jest tests easier, but providing CJS and ESM builds seems generally good. As far as testing goes, another option would be switching from webpack+jest to vite+vitest. Vitest has almost exactly the same API as jest but supports ESM imports.
