### PR TITLE
Rename the path the generate scripts expect

### DIFF
--- a/config/typescript-axios-v0.yaml
+++ b/config/typescript-axios-v0.yaml
@@ -1,7 +1,7 @@
 generatorName: typescript-axios
-outputDir: open-api-clients/src/typescript/mit-open-api-axios/src/v0
+outputDir: mit-open-api-clients/src/typescript/mit-open-api-axios/src/v0
 inputSpec: mit-open/openapi/specs/v0.yaml
-ignoreFileOverride: open-api-clients/.openapi-generator-ignore
+ignoreFileOverride: mit-open-api-clients/.openapi-generator-ignore
 additionalProperties:
   globalProperty: apis,models
   paramNaming: original

--- a/config/typescript-axios-v1.yaml
+++ b/config/typescript-axios-v1.yaml
@@ -1,7 +1,7 @@
 generatorName: typescript-axios
-outputDir: open-api-clients/src/typescript/mit-open-api-axios/src/v1
+outputDir: mit-open-api-clients/src/typescript/mit-open-api-axios/src/v1
 inputSpec: mit-open/openapi/specs/v1.yaml
-ignoreFileOverride: open-api-clients/.openapi-generator-ignore
+ignoreFileOverride: mit-open-api-clients/.openapi-generator-ignore
 additionalProperties:
   globalProperty: apis,models
   paramNaming: original

--- a/scripts/generate-inner.sh
+++ b/scripts/generate-inner.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-for cfile in open-api-clients/config/*.yaml; do
+for cfile in mit-open-api-clients/config/*.yaml; do
 	echo "Generating: $cfile"
 	/usr/local/bin/docker-entrypoint.sh generate -c "$cfile"
 done

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -24,11 +24,11 @@ git checkout release
 popd
 
 docker run --rm \
-  -v "${PWD}:/tmp/open-api-clients" \
+  -v "${PWD}:/tmp/mit-open-api-clients" \
   -v "${OPEN_CLONE_DIR}:/tmp/mit-open" \
   -w /tmp \
   $GENERATOR_IMAGE \
-  ./open-api-clients/scripts/generate-inner.sh
+  ./mit-open-api-clients/scripts/generate-inner.sh
 
 
 # set permissions to host permissions so that we can modify files


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Related to https://github.com/mitodl/ol-infrastructure/pull/2303

### Description (What does it do?)
<!--- Describe your changes in detail -->
This renames the path the scripts and configs expect this repo to be mounted under to match the ol-infrastructure paths.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

You can run `./scripts/generate.sh` without errors. It's fine if it generates code changes.