### PR TITLE
prevent pre-commit from updating autogenerated files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: trailing-whitespace
         exclude: ^src/typescript/mit-learn-api-axios/src/v0|^src/typescript/mit-learn-api-axios/src/v1
       - id: end-of-file-fixer
-        exclude: .hbs$|^src/typescript/mit-learn-api-axios/src/v0|^src/typescript/mit-learn-api-axios/src/v1
+        exclude: '(\.hbs$|^src/typescript/mit-learn-api-axios/src/v[01]/)'
       - id: check-yaml
       - id: check-added-large-files
       - id: check-merge-conflict

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     rev: v4.5.0
     hooks:
       - id: trailing-whitespace
-        exclude: ^src/typescript/mit-learn-api-axios/src/v0|^src/typescript/mit-learn-api-axios/src/v1
+        exclude: '^src/typescript/mit-learn-api-axios/src/v[01]/'
       - id: end-of-file-fixer
         exclude: '(\.hbs$|^src/typescript/mit-learn-api-axios/src/v[01]/)'
       - id: check-yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     rev: v4.5.0
     hooks:
       - id: trailing-whitespace
-        exclude: '^src/typescript/mit-learn-api-axios/src/v[01]/'
+        exclude: "^src/typescript/mit-learn-api-axios/src/v[01]/"
       - id: end-of-file-fixer
         exclude: '(\.hbs$|^src/typescript/mit-learn-api-axios/src/v[01]/)'
       - id: check-yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,8 +10,9 @@ repos:
     rev: v4.5.0
     hooks:
       - id: trailing-whitespace
+        exclude: ^src/typescript/mit-learn-api-axios/src/v0|^src/typescript/mit-learn-api-axios/src/v1
       - id: end-of-file-fixer
-        exclude: ".hbs$"
+        exclude: .hbs$|^src/typescript/mit-learn-api-axios/src/v0|^src/typescript/mit-learn-api-axios/src/v1
       - id: check-yaml
       - id: check-added-large-files
       - id: check-merge-conflict
@@ -25,6 +26,7 @@ repos:
         args:
           - --no-config
           - --no-semi
+        exclude: ^src/typescript/mit-learn-api-axios/src/v0|^src/typescript/mit-learn-api-axios/src/v1
   - repo: https://github.com/scop/pre-commit-shfmt
     rev: v3.7.0-4
     hooks:


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
This came up while looking at https://github.com/mitodl/mit-learn-api-clients/pull/56. That is a simple lockfile update, however, the diff is much larger than it should be, as pre-commit modifies the autogenerated api client files. This makes it harder to review the actual dependency changes.

This change prevents prettier and a couple other hooks from running on the autogenerated client files.

There is an earlier PR for this at https://github.com/mitodl/mit-learn-api-clients/pull/57 but it seems to have been abandoned and doesn't seem to work anymore.

### How can this be tested?
1. The pre-commit-ci bot must not add any commit to this PR. 
2. pre-commit run --all-files should report no errors
